### PR TITLE
Exclude MISSING when counting alleles per site

### DIFF
--- a/tests/test_API.py
+++ b/tests/test_API.py
@@ -86,15 +86,24 @@ class LSBase:
         n = H.shape[1]
         m = ts.get_num_sites()
 
+        def _get_num_alleles(ref_haps, query):
+            assert ref_haps.shape[0] == query.shape[1]
+            num_sites = ref_haps.shape[0]
+            num_alleles = np.zeros(num_sites, dtype=np.int8)
+            exclusion_set = np.array([MISSING])
+            for i in range(num_sites):
+                uniq_alleles = np.unique(np.append(ref_haps[i, :], query[:, i]))
+                num_alleles[i] = np.sum(~np.isin(uniq_alleles, exclusion_set))
+            assert np.all(num_alleles >= 0), "Number of alleles cannot be zero."
+            return num_alleles
+
         # Here we have equal mutation and recombination
         r = np.zeros(m) + 0.01
         mu = np.zeros(m) + 0.01
         r[0] = 0
 
         for s in haplotypes:
-            n_alleles = np.int8(
-                [len(np.unique(np.append(H[j, :], s[:, j]))) for j in range(m)]
-            )
+            n_alleles = _get_num_alleles(H, s)
             e = self.haplotype_emission(
                 mu, m, n_alleles, scale_mutation_based_on_n_alleles=scale_mutation
             )
@@ -106,9 +115,7 @@ class LSBase:
 
         for s, r, mu in itertools.product(haplotypes, rs, mus):
             r[0] = 0
-            n_alleles = np.int8(
-                [len(np.unique(np.append(H[j, :], s[:, j]))) for j in range(H.shape[0])]
-            )
+            n_alleles = _get_num_alleles(H, s)
             e = self.haplotype_emission(
                 mu, m, n_alleles, scale_mutation_based_on_n_alleles=scale_mutation
             )


### PR DESCRIPTION
Fix #33

I reworked `check_alleles` in `lshmm/api.py`.

I implemented a helper function `_get_num_alleles`, which has the same logic as `check_alleles`, in the following two test files:
* `test_API.py`
* `test_API_multiallelic.py`

The above sets of tests pass.

I did not make any changes to `test_LS_haploid_diploid.py`, because there is no testing of FB when mutation rates are scaled by the number of distinct alleles.

Also, I'm only dealing with `MISSING` here. I'll add `NONCOPY` to the exclusion set in #31.