### PR TITLE
Refactor set_emission_probabilities

### DIFF
--- a/lshmm/api.py
+++ b/lshmm/api.py
@@ -118,21 +118,11 @@ def check_inputs(
 def set_emission_probabilities(
     num_ref_haps,
     num_sites,
-    reference_panel,
-    query,
     ploidy,
-    alleles,
+    num_alleles,
     prob_mutation,
     scale_mutation_rate,
 ):
-    # Check alleles should go in here, and modify e before passing to the algorithm
-    # If alleles is not passed, we don't perform a test of alleles,
-    # but set n_alleles based on the reference_panel.
-    if alleles is None:
-        num_alleles = core.get_num_alleles(reference_panel, query)
-    else:
-        num_alleles = core.check_alleles(alleles, num_sites)
-
     if prob_mutation is None:
         # Set the mutation probability to be that proposed in Li & Stephens (2003).
         theta_tilde = 1 / np.sum([1 / k for k in range(1, num_ref_haps - 1)])
@@ -159,10 +149,10 @@ def set_emission_probabilities(
 def forwards(
     reference_panel,
     query,
+    num_alleles,
     prob_recombination,
     *,
     prob_mutation=None,
-    alleles=None,
     scale_mutation_rate=None,
     normalise=None,
 ):
@@ -184,10 +174,8 @@ def forwards(
     emission_probs = set_emission_probabilities(
         num_ref_haps=num_ref_haps,
         num_sites=num_sites,
-        reference_panel=reference_panel,
-        query=query,
         ploidy=ploidy,
-        alleles=alleles,
+        num_alleles=num_alleles,
         prob_mutation=prob_mutation,
         scale_mutation_rate=scale_mutation_rate,
     )
@@ -217,11 +205,11 @@ def forwards(
 def backwards(
     reference_panel,
     query,
+    num_alleles,
     normalisation_factor_from_forward,
     prob_recombination,
     *,
     prob_mutation=None,
-    alleles=None,
     scale_mutation_rate=None,
 ):
     """Run the backwards algorithm on haplotype or unphased genotype data."""
@@ -239,10 +227,8 @@ def backwards(
     emission_probs = set_emission_probabilities(
         num_ref_haps=num_ref_haps,
         num_sites=num_sites,
-        reference_panel=reference_panel,
-        query=query,
         ploidy=ploidy,
-        alleles=alleles,
+        num_alleles=num_alleles,
         prob_mutation=prob_mutation,
         scale_mutation_rate=scale_mutation_rate,
     )
@@ -268,10 +254,10 @@ def backwards(
 def viterbi(
     reference_panel,
     query,
+    num_alleles,
     prob_recombination,
     *,
     prob_mutation=None,
-    alleles=None,
     scale_mutation_rate=None,
 ):
     """Run the Viterbi algorithm on haplotype or unphased genotype data."""
@@ -289,10 +275,8 @@ def viterbi(
     emission_probs = set_emission_probabilities(
         num_ref_haps=num_ref_haps,
         num_sites=num_sites,
-        reference_panel=reference_panel,
-        query=query,
         ploidy=ploidy,
-        alleles=alleles,
+        num_alleles=num_alleles,
         prob_mutation=prob_mutation,
         scale_mutation_rate=scale_mutation_rate,
     )
@@ -325,11 +309,11 @@ def viterbi(
 def path_loglik(
     reference_panel,
     query,
+    num_alleles,
     path,
     prob_recombination,
     *,
     prob_mutation=None,
-    alleles=None,
     scale_mutation_rate=None,
 ):
     """Evaluate the log-likelihood of a copying path for a query through a reference panel."""
@@ -347,10 +331,8 @@ def path_loglik(
     emission_probs = set_emission_probabilities(
         num_ref_haps=num_ref_haps,
         num_sites=num_sites,
-        reference_panel=reference_panel,
-        query=query,
         ploidy=ploidy,
-        alleles=alleles,
+        num_alleles=num_alleles,
         prob_mutation=prob_mutation,
         scale_mutation_rate=scale_mutation_rate,
     )

--- a/tests/lsbase.py
+++ b/tests/lsbase.py
@@ -138,25 +138,21 @@ class LSBase:
             mus.append(np.zeros(m) + 0.2)
             mus.append(np.zeros(m) + 1e-6)
 
-        if ploidy == 2:
-            G = core.convert_haplotypes_to_phased_genotypes(H)
-
-        for s, r, mu in itertools.product(queries, rs, mus):
+        for query, r, mu in itertools.product(queries, rs, mus):
             r[0] = 0
             # Must be calculated from the genotype matrix,
             # because we can now get back mutations that
             # result in the number of alleles being higher
             # than the number of alleles in the reference panel.
-            num_alleles = core.get_num_alleles(H, s)
+            num_alleles = core.get_num_alleles(H, query)
             if ploidy == 1:
                 e = core.get_emission_matrix_haploid(
                     mu, m, num_alleles, scale_mutation_rate
                 )
-                yield n, m, H, s, e, r, mu
+                yield n, m, H, query, e, r, mu
             else:
-                Q = core.convert_haplotypes_to_unphased_genotypes(query=s)
                 e = core.get_emission_matrix_diploid(mu, m)
-                yield n, m, G, Q, e, r, mu
+                yield n, m, H, query, e, r, mu
 
     # Prepare simple example datasets.
     def get_ts_simple_n10_no_recomb(self, seed=42):

--- a/tests/test_API.py
+++ b/tests/test_API.py
@@ -1,6 +1,8 @@
 import pytest
+
 from . import lsbase
 import lshmm as ls
+import lshmm.core as core
 import lshmm.fb_diploid as fbd
 import lshmm.fb_haploid as fbh
 import lshmm.vit_diploid as vd
@@ -16,10 +18,42 @@ class TestForwardBackwardHaploid(lsbase.ForwardBackwardAlgorithmBase):
             include_ancestors=include_ancestors,
             include_extreme_rates=True,
         ):
-            F_vs, c_vs, ll_vs = fbh.forwards_ls_hap(n, m, H_vs, s, e_vs, r)
-            B_vs = fbh.backwards_ls_hap(n, m, H_vs, s, e_vs, c_vs, r)
-            F, c, ll = ls.forwards(H_vs, s, r, prob_mutation=mu)
-            B = ls.backwards(H_vs, s, c, r, prob_mutation=mu)
+            num_alleles = core.get_num_alleles(H_vs, s)
+            F_vs, c_vs, ll_vs = fbh.forwards_ls_hap(
+                n=n,
+                m=m,
+                H=H_vs,
+                s=s,
+                e=e_vs,
+                r=r,
+            )
+            B_vs = fbh.backwards_ls_hap(
+                n=n,
+                m=m,
+                H=H_vs,
+                s=s,
+                e=e_vs,
+                c=c_vs,
+                r=r,
+            )
+            F, c, ll = ls.forwards(
+                reference_panel=H_vs,
+                query=s,
+                num_alleles=num_alleles,
+                prob_recombination=r,
+                prob_mutation=mu,
+                scale_mutation_rate=scale_mutation_rate,
+                normalise=True,
+            )
+            B = ls.backwards(
+                reference_panel=H_vs,
+                query=s,
+                num_alleles=num_alleles,
+                normalisation_factor_from_forward=c,
+                prob_recombination=r,
+                prob_mutation=mu,
+                scale_mutation_rate=scale_mutation_rate,
+            )
             self.assertAllClose(F, F_vs)
             self.assertAllClose(B, B_vs)
             self.assertAllClose(ll_vs, ll)
@@ -63,19 +97,53 @@ class TestForwardBackwardHaploid(lsbase.ForwardBackwardAlgorithmBase):
 
 class TestForwardBackwardDiploid(lsbase.ForwardBackwardAlgorithmBase):
     def verify(self, ts, scale_mutation_rate, include_ancestors):
-        for n, m, G_vs, s, e_vs, r, mu in self.get_examples_pars(
+        for n, m, H_vs, query, e_vs, r, mu in self.get_examples_pars(
             ts,
             ploidy=2,
             scale_mutation_rate=scale_mutation_rate,
             include_ancestors=include_ancestors,
             include_extreme_rates=True,
         ):
+            G_vs = core.convert_haplotypes_to_phased_genotypes(H_vs)
+            s = core.convert_haplotypes_to_unphased_genotypes(query)
+            num_alleles = core.get_num_alleles(H_vs, query)
             F_vs, c_vs, ll_vs = fbd.forward_ls_dip_loop(
-                n, m, G_vs, s, e_vs, r, norm=True
+                n=n,
+                m=m,
+                G=G_vs,
+                s=s,
+                e=e_vs,
+                r=r,
+                norm=True,
             )
-            F, c, ll = ls.forwards(G_vs, s, r, prob_mutation=mu)
-            B_vs = fbd.backward_ls_dip_loop(n, m, G_vs, s, e_vs, c_vs, r)
-            B = ls.backwards(G_vs, s, c, r, prob_mutation=mu)
+            B_vs = fbd.backward_ls_dip_loop(
+                n=n,
+                m=m,
+                G=G_vs,
+                s=s,
+                e=e_vs,
+                c=c_vs,
+                r=r,
+            )
+            F, c, ll = ls.forwards(
+                reference_panel=G_vs,
+                query=s,
+                num_alleles=num_alleles,
+                prob_recombination=r,
+                prob_mutation=mu,
+                scale_mutation_rate=scale_mutation_rate,
+                normalise=True,
+            )
+            B = ls.backwards(
+                reference_panel=G_vs,
+                query=s,
+                num_alleles=num_alleles,
+                normalisation_factor_from_forward=c,
+                prob_recombination=r,
+                prob_mutation=mu,
+                scale_mutation_rate=scale_mutation_rate,
+            )
+
             self.assertAllClose(F, F_vs)
             self.assertAllClose(B, B_vs)
             self.assertAllClose(ll_vs, ll)
@@ -126,11 +194,24 @@ class TestViterbiHaploid(lsbase.ViterbiAlgorithmBase):
             include_ancestors=include_ancestors,
             include_extreme_rates=True,
         ):
+            num_alleles = core.get_num_alleles(H_vs, s)
             V_vs, P_vs, ll_vs = vh.forwards_viterbi_hap_lower_mem_rescaling(
-                n, m, H_vs, s, e_vs, r
+                n=n,
+                m=m,
+                H=H_vs,
+                s=s,
+                e=e_vs,
+                r=r,
             )
-            path_vs = vh.backwards_viterbi_hap(m, V_vs, P_vs)
-            path, ll = ls.viterbi(H_vs, s, r, prob_mutation=mu)
+            path_vs = vh.backwards_viterbi_hap(m=m, V_last=V_vs, P=P_vs)
+            path, ll = ls.viterbi(
+                reference_panel=H_vs,
+                query=s,
+                num_alleles=num_alleles,
+                prob_recombination=r,
+                prob_mutation=mu,
+                scale_mutation_rate=scale_mutation_rate,
+            )
             self.assertAllClose(ll_vs, ll)
             self.assertAllClose(path_vs, path)
 
@@ -173,17 +254,34 @@ class TestViterbiHaploid(lsbase.ViterbiAlgorithmBase):
 
 class TestViterbiDiploid(lsbase.ViterbiAlgorithmBase):
     def verify(self, ts, scale_mutation_rate, include_ancestors):
-        for n, m, G_vs, s, e_vs, r, mu in self.get_examples_pars(
+        for n, m, H_vs, query, e_vs, r, mu in self.get_examples_pars(
             ts,
             ploidy=2,
             scale_mutation_rate=scale_mutation_rate,
             include_ancestors=include_ancestors,
             include_extreme_rates=True,
         ):
-            V_vs, P_vs, ll_vs = vd.forwards_viterbi_dip_low_mem(n, m, G_vs, s, e_vs, r)
-            path_vs = vd.backwards_viterbi_dip(m, V_vs, P_vs)
-            phased_path_vs = vd.get_phased_path(n, path_vs)
-            path, ll = ls.viterbi(G_vs, s, r, prob_mutation=mu)
+            G_vs = core.convert_haplotypes_to_phased_genotypes(H_vs)
+            s = core.convert_haplotypes_to_unphased_genotypes(query)
+            num_alleles = core.get_num_alleles(H_vs, query)
+            V_vs, P_vs, ll_vs = vd.forwards_viterbi_dip_low_mem(
+                n=n,
+                m=m,
+                G=G_vs,
+                s=s,
+                e=e_vs,
+                r=r,
+            )
+            path_vs = vd.backwards_viterbi_dip(m=m, V_last=V_vs, P=P_vs)
+            phased_path_vs = vd.get_phased_path(n=n, path=path_vs)
+            path, ll = ls.viterbi(
+                reference_panel=G_vs,
+                query=s,
+                num_alleles=num_alleles,
+                prob_recombination=r,
+                prob_mutation=mu,
+                scale_mutation_rate=scale_mutation_rate,
+            )
             self.assertAllClose(ll_vs, ll)
             self.assertAllClose(phased_path_vs, path)
 


### PR DESCRIPTION
Refactor `set_emission_probabilities` to take `num_alleles` as a required parameter rather than a variable calculated from `reference_panel` and `query`. The functions `forwards`, `backwards`, `viterbi`, and `path_loglik` have to be modified accordingly. The tests have to be modified as well. The result of this is that either form of reference panel and query (as haplotypes or genotypes encoded as allele dosages) can be passed to the API functions without needing to pass in both forms when running the diploid implementations.