### PR TITLE
Remove old package from setup config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ classifiers =
 [options]
 packages = 
     lshmm
-    lshmm.forward_backward
 install_requires =
     numba
 python_requires = >=3.7


### PR DESCRIPTION
Remove `lshmm.forward_backward` as it is no longer in the current version. Partially address #116 