### PR TITLE
Refactor tests for haploid case with multiallelic sites

### DIFF
--- a/tests/lsbase.py
+++ b/tests/lsbase.py
@@ -287,10 +287,10 @@ class LSBase:
         assert ts.num_sites > 3
         return ts
 
-    def get_ts_multiallelic_n6(self, seed=42):
+    def get_ts_multiallelic(self, num_samples, seed=42):
         ts = msprime.sim_mutations(
             msprime.sim_ancestry(
-                samples=6,
+                samples=num_samples,
                 recombination_rate=1e-4,
                 sequence_length=40,
                 population_size=1e4,
@@ -299,37 +299,7 @@ class LSBase:
             rate=1e-3,
             random_seed=seed,
         )
-        assert ts.num_sites > 5
-        return ts
-
-    def get_ts_multiallelic_n8(self, seed=42):
-        ts = msprime.sim_mutations(
-            msprime.sim_ancestry(
-                samples=8,
-                recombination_rate=1e-4,
-                sequence_length=20,
-                population_size=1e4,
-                random_seed=seed,
-            ),
-            rate=1e-4,
-            random_seed=seed,
-        )
         assert ts.num_trees > 15
-        assert ts.num_sites > 5
-        return ts
-
-    def get_ts_multiallelic_n16(self, seed=42):
-        ts = msprime.sim_mutations(
-            msprime.sim_ancestry(
-                samples=16,
-                recombination_rate=1e-2,
-                sequence_length=20,
-                population_size=1e4,
-                random_seed=seed,
-            ),
-            rate=1e-4,
-            random_seed=seed,
-        )
         assert ts.num_sites > 5
         return ts
 

--- a/tests/test_api_fb_haploid_multi.py
+++ b/tests/test_api_fb_haploid_multi.py
@@ -61,38 +61,13 @@ class TestForwardBackwardHaploid(lsbase.ForwardBackwardAlgorithmBase):
         self, scale_mutation_rate, include_ancestors
     ):
         ts = self.get_ts_multiallelic_n10_no_recomb()
-        self.verify(
-            ts,
-            scale_mutation_rate=scale_mutation_rate,
-            include_ancestors=include_ancestors,
-        )
+        self.verify(ts, scale_mutation_rate, include_ancestors)
 
+    @pytest.mark.parametrize("num_samples", [6, 8, 16])
     @pytest.mark.parametrize("scale_mutation_rate", [True, False])
     @pytest.mark.parametrize("include_ancestors", [True, False])
-    def test_ts_multiallelic_n6(self, scale_mutation_rate, include_ancestors):
-        ts = self.get_ts_multiallelic_n6()
-        self.verify(
-            ts,
-            scale_mutation_rate=scale_mutation_rate,
-            include_ancestors=include_ancestors,
-        )
-
-    @pytest.mark.parametrize("scale_mutation_rate", [True, False])
-    @pytest.mark.parametrize("include_ancestors", [True, False])
-    def test_ts_multiallelic_n8(self, scale_mutation_rate, include_ancestors):
-        ts = self.get_ts_multiallelic_n8()
-        self.verify(
-            ts,
-            scale_mutation_rate=scale_mutation_rate,
-            include_ancestors=include_ancestors,
-        )
-
-    @pytest.mark.parametrize("scale_mutation_rate", [True, False])
-    @pytest.mark.parametrize("include_ancestors", [True, False])
-    def test_ts_multiallelic_n16(self, scale_mutation_rate, include_ancestors):
-        ts = self.get_ts_multiallelic_n16()
-        self.verify(
-            ts,
-            scale_mutation_rate=scale_mutation_rate,
-            include_ancestors=include_ancestors,
-        )
+    def test_ts_multiallelic_n16(
+        self, num_samples, scale_mutation_rate, include_ancestors
+    ):
+        ts = self.get_ts_multiallelic(num_samples)
+        self.verify(ts, scale_mutation_rate, include_ancestors)

--- a/tests/test_api_vit_haploid_multi.py
+++ b/tests/test_api_vit_haploid_multi.py
@@ -50,32 +50,11 @@ class TestViterbiHaploid(lsbase.ViterbiAlgorithmBase):
             include_ancestors=include_ancestors,
         )
 
+    @pytest.mark.parametrize("num_samples", [6, 8, 16])
     @pytest.mark.parametrize("scale_mutation_rate", [True, False])
     @pytest.mark.parametrize("include_ancestors", [True, False])
-    def test_ts_multiallelic_n6(self, scale_mutation_rate, include_ancestors):
-        ts = self.get_ts_multiallelic_n6()
-        self.verify(
-            ts,
-            scale_mutation_rate=scale_mutation_rate,
-            include_ancestors=include_ancestors,
-        )
-
-    @pytest.mark.parametrize("scale_mutation_rate", [True, False])
-    @pytest.mark.parametrize("include_ancestors", [True, False])
-    def test_ts_multiallelic_n8(self, scale_mutation_rate, include_ancestors):
-        ts = self.get_ts_multiallelic_n8()
-        self.verify(
-            ts,
-            scale_mutation_rate=scale_mutation_rate,
-            include_ancestors=include_ancestors,
-        )
-
-    @pytest.mark.parametrize("scale_mutation_rate", [True, False])
-    @pytest.mark.parametrize("include_ancestors", [True, False])
-    def test_ts_multiallelic_n16(self, scale_mutation_rate, include_ancestors):
-        ts = self.get_ts_multiallelic_n16()
-        self.verify(
-            ts,
-            scale_mutation_rate=scale_mutation_rate,
-            include_ancestors=include_ancestors,
-        )
+    def test_ts_multiallelic_n16(
+        self, num_samples, scale_mutation_rate, include_ancestors
+    ):
+        ts = self.get_ts_multiallelic(num_samples)
+        self.verify(ts, scale_mutation_rate, include_ancestors)


### PR DESCRIPTION
Refactor so it's easier to extend tests for more flexible models involving multiple allelic states.