### PR TITLE
Update to require python 3.10 and disable numba caching

### DIFF
--- a/lshmm/core.py
+++ b/lshmm/core.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from lshmm import jit
 
-
 EQUAL_BOTH_HOM = 4
 UNEQUAL_BOTH_HOM = 0
 BOTH_HET = 7

--- a/lshmm/jit.py
+++ b/lshmm/jit.py
@@ -25,7 +25,7 @@ if not ENABLE_NUMBA:
 
 DEFAULT_NUMBA_ARGS = {
     "nopython": True,
-    "cache": True,
+    "cache": False,
 }
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,11 +12,11 @@ classifiers =
     Programming Language :: Python :: 3
 
 [options]
-packages = 
+packages =
     lshmm
 install_requires =
     numba
-python_requires = >=3.7
+python_requires = >=3.10
 include_package_data = True
 
 [options.packages.find]


### PR DESCRIPTION
It appears that 2 tests are broken if ~python < 3.12~ cache=True in numba, ~so we could skip those if need be, or set the min requirements to 3.12 rather than the 3.10 that I set it to here~.